### PR TITLE
Significantly optimized every listener in Listeners.java

### DIFF
--- a/src/main/java/dev/foxikle/customnpcs/internal/listeners/Listeners.java
+++ b/src/main/java/dev/foxikle/customnpcs/internal/listeners/Listeners.java
@@ -1,5 +1,6 @@
 package dev.foxikle.customnpcs.internal.listeners;
 
+import dev.foxikle.customnpcs.internal.menu.MenuCore;
 import dev.foxikle.customnpcs.api.Action;
 import dev.foxikle.customnpcs.internal.CustomNPCs;
 import dev.foxikle.customnpcs.internal.InternalNpc;
@@ -12,35 +13,160 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.*;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import java.util.regex.Pattern;
 /**
  * The class that deals with misc listeners
  */
 public class Listeners implements Listener {
+	/**
+	 * Player Movement Data that keeps track of old movements to replace PlayerMoveEvent
+	 * @since *Insert_Version*
+	 */
+	private static final ConcurrentMap<UUID, MovementData> playerMovementData = new ConcurrentHashMap<>();
+	
+	// Helper Constants
+	// since *Insert_Version*
+	private static final int FIVE_BLOCKS = 25;
+	private static final int FIFTY_BLOCKS = 2500; // 50 * 50
+	private static final int FOURTY_BLOCKS = 2304; // 48 * 48
+	private static final double HALF_BLOCK = 0.25;
+	
+	// Writing Constants
+	// since *Insert_Version*
+	private static final BukkitScheduler SCHEDULER = Bukkit.getScheduler();
+	
+	private static final String SHOULD_UPDATE_MESSAGE =
+		ChatColor.translateAlternateColorCodes('&', "&2&m----------------&r &6[&e!&6] &b&lCustomNPCs &6[&e!&6]  &2&m----------------\n&r&eA new update is available! I'd appreciate if you updated :) \n -&e&oFoxikle");
+		
+	private static final ConsoleCommandSender sender = Bukkit.getConsoleSender();
+	
+	private static final Pattern PATTERN = Pattern.compile(" ");
+	
     /**
      * The instance of the main Class
      */
     private final CustomNPCs plugin;
-
+    
+    // Executors for better handling of async scheduling than that bukkit scheduler
+    private final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+    //private final ExecutorService executorService = Executors.newFixedThreadPool(1);
     /**
      * Constructor for generic listners class
      * @param plugin The instance of the main class
      */
     public Listeners(CustomNPCs plugin) {
         this.plugin = plugin;
+        service.scheduleAtFixedRate(() -> Bukkit.getOnlinePlayers().forEach(this::actionPlayerMovement), 1000, 220, TimeUnit.MILLISECONDS);
+    }
+    
+    public void stop() {
+		service.shutdown();
+		//executorService.shutdown();
+		CompletableFuture.runAsync(() -> {
+			try {
+				if (/*!executorService.awaitTermination(2, TimeUnit.SECONDS) 
+						|| */!service.awaitTermination(2, TimeUnit.SECONDS)) {
+					//executorService.shutdownNow();
+					service.shutdownNow();
+				}
+			} catch (InterruptedException e) {
+				//executorService.shutdownNow();
+				service.shutdownNow();
+				Thread.currentThread().interrupt();
+			}
+		});
+	}
+    
+    private final void actionPlayerMovement(Player player) {
+		final Location location = player.getLocation();
+		final World world = player.getWorld();
+		
+		final UUID uuid = player.getUniqueId();
+		for (InternalNpc npc : plugin.npcs.values()) {
+			if (npc.getTarget() != null) continue;
+			
+			World npcWorld = npc.getWorld();
+			if (world != npcWorld) continue;
+			if (npc.isTunnelVision()) continue;
+			processPlayerMovement(player, npc, world, npcWorld, location, uuid);
+		}
+	}
+    
+    private final void processPlayerMovement(final Player player, 
+    									final InternalNpc npc, 
+    									final World world, 
+    									final World npcWorld,
+    									final Location location,
+    									final UUID uuid) {
+    	final Location npcLocation = npc.getCurrentLocation(); 
+    	MovementData oldMovementData; // difference in order of initialization in if/else statement
+        final MovementData movementData = playerMovementData.get(uuid);
+        final double distanceSquared = location.distanceSquared(npcLocation);
+        if (movementData == null) {
+        	playerMovementData.put(uuid, new MovementData(uuid, location, distanceSquared));
+        	movementData = playerMovementData.get(uuid);
+        	oldMovementData = movementData;
+        } else {
+        	oldMovementData = movementData;
+			movementData.setLastLocation(location);
+			movementData.setDistanceSquared(distanceSquared);
+		}
+    	trackFromTo(player, npc, world, npcWorld, location, npcLocation, uuid, movementData, oldMovementData);
+        if (distanceSquared > FIVE_BLOCKS) {
+            Collection<Entity> entities = npcWorld.getNearbyEntities(location, 2.5, 2.5, 2.5);
+            entities.removeIf(entity -> entity.getScoreboardTags().contains("NPC"));
+            for (Entity en : entities) {
+                if (!(en instanceof Player p)) continue;
+                npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) p).getHandle(), EntityAnchorArgument.Anchor.EYES);
+            }
+            float direction = (float) npc.getFacingDirection();
+            npc.setYBodyRot(direction);
+            npc.setYRot(direction);
+            npc.setYHeadRot(direction);
+        }
+    }
+    
+    private final void trackFromTo(Player player, 
+    							   InternalNpc npc, 
+    							   World world, 
+    							   World npcWorld,
+    							   Location location,
+    							   Location npcLocation,
+    							   UUID uuid, 
+    							   MovementData data,
+    							   MovementData oldData) {
+    	if (data.distanceSquared <= FIVE_BLOCKS) {
+            npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
+        	return;
+        } else if (oldData.distanceSquared >= FOURTY_BLOCKS && data.distanceSquared <= FIFTY_BLOCKS) {
+            npc.injectPlayer(player);
+        }
     }
 
     /**
@@ -51,23 +177,24 @@ public class Listeners implements Listener {
      */
     @EventHandler
     public void onPlayerInteract(PlayerInteractEntityEvent e) {
-        if (e.getHand() == EquipmentSlot.HAND) {
-            if (e.getRightClicked().getType() == EntityType.PLAYER) {
-                Player player = e.getPlayer();
-                Player rightClicked = (Player) e.getRightClicked();
-                ServerPlayer sp = ((CraftPlayer) rightClicked).getHandle();
-                InternalNpc npc;
-                try {
-                    npc = plugin.getNPCByID(sp.getUUID());
-                } catch (IllegalArgumentException ignored){
-                    return;
-                }
-                if (player.hasPermission("customnpcs.edit") && player.isSneaking()) {
-                    player.performCommand("npc edit " + npc.getUUID());
-                } else if (npc.isClickable()) {
-                    npc.getActions().forEach(action -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), action.getCommand(e.getPlayer())));
-                }
-            }
+    	Player player = e.getPlayer();
+    	
+        if (e.getHand() != EquipmentSlot.HAND) return; 
+        if (e.getRightClicked().getType() != EntityType.PLAYER) return;
+        Player rightClicked = (Player) e.getRightClicked();
+        ServerPlayer sp = ((CraftPlayer) rightClicked).getHandle();
+        InternalNpc npc;
+        
+        UUID uuid = sp.getUUID();
+        try {
+            npc = plugin.getNPCByID(uuid);
+        } catch (IllegalArgumentException ignored){
+            return;
+        }
+        if (player.hasPermission("customnpcs.edit") && player.isSneaking()) {
+            player.performCommand("npc edit " + uuid);
+        } else if (npc.isClickable()) {
+            npc.getActions().forEach(action -> Bukkit.dispatchCommand(sender, action.getCommand(player)));
         }
     }
 
@@ -79,88 +206,75 @@ public class Listeners implements Listener {
      */
     @EventHandler (priority = EventPriority.HIGHEST)
     public void onChat(AsyncPlayerChatEvent e) {
-        if (plugin.commandWaiting.contains(e.getPlayer())) {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                plugin.commandWaiting.remove(e.getPlayer());
-                Action action = plugin.editingActions.get(e.getPlayer());
-                List<String> currentArgs = action.getArgs();
-                currentArgs.clear();
-                currentArgs.addAll(List.of(e.getMessage().split(" ")));
-                e.getPlayer().sendMessage(ChatColor.GREEN + "Successfully set command to be '" + ChatColor.RESET + ChatColor.translateAlternateColorCodes('&', e.getMessage()) + ChatColor.RESET + "" + ChatColor.GREEN + "'");
-                Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getActionCustomizerMenu(action)));
-            });
-            e.setCancelled(true);
-        } else if (plugin.nameWaiting.contains(e.getPlayer())) {
-            plugin.nameWaiting.remove(e.getPlayer());
-            plugin.menuCores.get(e.getPlayer()).getNpc().setName(e.getMessage());
-            e.getPlayer().sendMessage(Component.text("Successfully set name to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(e.getMessage())).append(Component.text("'", NamedTextColor.GREEN)));
-            Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getMainMenu()));
-            e.setCancelled(true);
-        } else if (plugin.targetWaiting.contains(e.getPlayer())) {
+    	Player player = e.getPlayer();  
+    	String message = e.getMessage();
+    	MenuCore core = plugin.menuCores.get(player);
+        if (plugin.commandWaiting.contains(player)) {
+            plugin.commandWaiting.remove(player);
+            Action action = plugin.editingActions.get(player);
+            List<String> currentArgs = action.getArgs();
+            currentArgs.clear();
+            currentArgs.addAll(List.of(PATTERN.split(message)));
+            player.sendMessage(ChatColor.GREEN + "Successfully set command to be '" + ChatColor.RESET + ChatColor.translateAlternateColorCodes('&', message) + ChatColor.RESET + "" + ChatColor.GREEN + "'");
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getActionCustomizerMenu(action)));
+        } else if (plugin.nameWaiting.contains(player)) {
+            plugin.nameWaiting.remove(player);
+            core.getNpc().setName(message);
+            player.sendMessage(Component.text("Successfully set name to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(message)).append(Component.text("'", NamedTextColor.GREEN)));
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getMainMenu()));
+        } else if (plugin.targetWaiting.contains(player)) {
 
-            Conditional conditional = plugin.editingConditionals.get(e.getPlayer());
-            if(conditional.getType() == Conditional.Type.NUMERIC) {
+            Conditional conditional = plugin.editingConditionals.get(player);
+            if (conditional.getType() == Conditional.Type.NUMERIC) {
                 try {
-                    Double.parseDouble(e.getMessage());
+                    Double.parseDouble(message);
                 } catch (NumberFormatException ignored) {
-                    e.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', "&cCannot parse the number '&f" + e.getMessage() + "&c'. Please try again."));
+                    player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cCannot parse the number '&f" + message + "&c'. Please try again."));
                     return;
                 }
             }
-            plugin.targetWaiting.remove(e.getPlayer());
-            conditional.setTargetValue(e.getMessage());
-            e.getPlayer().sendMessage(ChatColor.GREEN + "Successfully set target to be '" + ChatColor.RESET + ChatColor.translateAlternateColorCodes('&', e.getMessage()) + ChatColor.RESET + ChatColor.GREEN + "'");
-            Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getConditionalCustomizerMenu(plugin.editingConditionals.get(e.getPlayer()))));
-            e.setCancelled(true);
-        } else if (plugin.titleWaiting.contains(e.getPlayer())) {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                plugin.titleWaiting.remove(e.getPlayer());
-                List<String> args = plugin.editingActions.get(e.getPlayer()).getArgsCopy();
-                Action action = plugin.editingActions.get(e.getPlayer());
-                List<String> currentArgs = action.getArgs();
-                currentArgs.clear();
-                currentArgs.add(0, args.get(0));
-                currentArgs.add(1, args.get(1));
-                currentArgs.add(2, args.get(2));
-                currentArgs.addAll(List.of(e.getMessage().split(" ")));
-                e.getPlayer().sendMessage(Component.text("Successfully set title to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(e.getMessage())).append(Component.text("'", NamedTextColor.GREEN)));
-                Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getActionCustomizerMenu(action)));
-            });
-            e.setCancelled(true);
-        } else if (plugin.messageWaiting.contains(e.getPlayer())) {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                plugin.messageWaiting.remove(e.getPlayer());
-                Action action = plugin.editingActions.get(e.getPlayer());
-                List<String> currentArgs = action.getArgs();
-                currentArgs.clear();
-                currentArgs.addAll(List.of(e.getMessage().split(" ")));
-                e.getPlayer().sendMessage(Component.text("Successfully set message to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(e.getMessage())).append(Component.text("'", NamedTextColor.GREEN)));
-                Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getActionCustomizerMenu(action)));
-            });
-            e.setCancelled(true);
-        } else if (plugin.serverWaiting.contains(e.getPlayer())) {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                plugin.serverWaiting.remove(e.getPlayer());
-                Action action = plugin.editingActions.get(e.getPlayer());
-                List<String> currentArgs = action.getArgs();
-                currentArgs.clear();
-                currentArgs.addAll(List.of(e.getMessage().split(" ")));
-                e.getPlayer().sendMessage(ChatColor.GREEN + "Successfully set server to be '" + ChatColor.RESET +  e.getMessage() + ChatColor.RESET + "" + ChatColor.GREEN + "'");
-                Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getActionCustomizerMenu(action)));
-            });
-            e.setCancelled(true);
-        } else if (plugin.actionbarWaiting.contains(e.getPlayer())) {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                plugin.actionbarWaiting.remove(e.getPlayer());
-                Action action = plugin.editingActions.get(e.getPlayer());
-                List<String> currentArgs = action.getArgs();
-                currentArgs.clear();
-                currentArgs.addAll(List.of(e.getMessage().split(" ")));
-                e.getPlayer().sendMessage(Component.text("Successfully set actionbar to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(e.getMessage())).append(Component.text("'", NamedTextColor.GREEN)));
-                Bukkit.getScheduler().runTask(plugin, () -> e.getPlayer().openInventory(plugin.menuCores.get(e.getPlayer()).getActionCustomizerMenu(action)));
-            });
-            e.setCancelled(true);
+            plugin.targetWaiting.remove(player);
+            conditional.setTargetValue(message);
+            player.sendMessage(ChatColor.translateAlternateColorCodes("&aSuccessfully set target to be '&r" + message + "&a'"));
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getConditionalCustomizerMenu(plugin.editingConditionals.get(player))));
+        } else if (plugin.titleWaiting.contains(player)) {
+            plugin.titleWaiting.remove(player);
+            List<String> args = plugin.editingActions.get(player).getArgsCopy();
+            Action action = plugin.editingActions.get(player);
+            List<String> currentArgs = action.getArgs();
+            currentArgs.clear();
+            currentArgs.add(0, args.get(0));
+            currentArgs.add(1, args.get(1));
+            currentArgs.add(2, args.get(2));
+            currentArgs.addAll(List.of(PATTERN.split(message)));
+            player.sendMessage(Component.text("Successfully set title to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(message)).append(Component.text("'", NamedTextColor.GREEN)));
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getActionCustomizerMenu(action)));
+        } else if (plugin.messageWaiting.contains(player)) {
+            plugin.messageWaiting.remove(player);
+            Action action = plugin.editingActions.get(player);
+            List<String> currentArgs = action.getArgs();
+            currentArgs.clear();
+            currentArgs.addAll(List.of(PATTERN.split(message)));
+            player.sendMessage(Component.text("Successfully set message to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(message)).append(Component.text("'", NamedTextColor.GREEN)));
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getActionCustomizerMenu(action)));
+        } else if (plugin.serverWaiting.contains(player)) {
+            plugin.serverWaiting.remove(player);
+            Action action = plugin.editingActions.get(player);
+            List<String> currentArgs = action.getArgs();
+            currentArgs.clear();
+            currentArgs.addAll(List.of(PATTERN.split(message)));
+            player.sendMessage(ChatColor.GREEN + "Successfully set server to be '" + ChatColor.RESET +  message + ChatColor.RESET + "" + ChatColor.GREEN + "'");
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getActionCustomizerMenu(action)));
+        } else if (plugin.actionbarWaiting.contains(player)) {
+            plugin.actionbarWaiting.remove(player);
+            Action action = plugin.editingActions.get(player);
+            List<String> currentArgs = action.getArgs();
+            currentArgs.clear();
+            currentArgs.addAll(List.of(PATTERN.split(message)));
+            player.sendMessage(Component.text("Successfully set actionbar to be '", NamedTextColor.GREEN).append(plugin.getMiniMessage().deserialize(message)).append(Component.text("'", NamedTextColor.GREEN)));
+            SCHEDULER.runTask(plugin, () -> player.openInventory(core.getActionCustomizerMenu(action)));
         }
+        e.setCancelled(true);
     }
 
     /**
@@ -171,54 +285,13 @@ public class Listeners implements Listener {
      */
     @EventHandler
     public void onPlayerLogin(PlayerJoinEvent e) {
-        if(plugin.update && plugin.getConfig().getBoolean("AlertOnUpdate")) {
-            if(e.getPlayer().hasPermission("customnpcs.alert")) {
-                e.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', "&2&m----------------&r &6[&e!&6] &b&lCustomNPCs &6[&e!&6]  &2&m----------------\n&r&eA new update is available! I'd appreciate if you updated :) \n -&e&oFoxikle"));
-            }
+    	Player player = e.getPlayer();
+        if (plugin.update && plugin.getConfig().getBoolean("AlertOnUpdate") && player.hasPermission("customnpcs.alert")) {
+        	player.sendMessage(SHOULD_UPDATE_MESSAGE);
         }
-        for (InternalNpc npc : plugin.getNPCs()) {
-            npc.injectPlayer(e.getPlayer());
-        }
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            for (InternalNpc npc : plugin.getNPCs()) {
-                npc.injectPlayer(e.getPlayer());
-            }
-        }, 10);
-    }
-
-    /**
-     * <p>The npc look handler
-     * </p>
-     * @param e The event callback
-     * @since 1.0
-     */
-    @EventHandler
-    public void onMove(PlayerMoveEvent e) {
-        Player player = e.getPlayer();
-        for (InternalNpc npc : plugin.npcs.values()) {
-            if(npc.getTarget() != null) return;
-            if(player.getWorld() != npc.getWorld()) return;
-            if(npc.isTunnelVision()) return;
-            if (e.getPlayer().getLocation().distance(npc.getCurrentLocation()) <= 5) {
-                npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
-            } else if (e.getFrom().distance(npc.getCurrentLocation()) >= 48 && e.getTo().distance(npc.getCurrentLocation()) <= 48) {
-                npc.injectPlayer(player);
-            }
-            if (e.getPlayer().getLocation().distance(npc.getCurrentLocation()) > 5) {
-                Collection<Entity> entities = npc.getWorld().getNearbyEntities(npc.getCurrentLocation(), 2.5, 2.5, 2.5);
-                entities.removeIf(entity -> entity.getScoreboardTags().contains("NPC"));
-                for (Entity en : entities) {
-                    if (en.getType() == EntityType.PLAYER) {
-                        Player p = (Player) en;
-                        npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) p).getHandle(), EntityAnchorArgument.Anchor.EYES);
-                        return;
-                    }
-                }
-                npc.setYBodyRot((float) npc.getFacingDirection());
-                npc.setYRot((float) npc.getFacingDirection());
-                npc.setYHeadRot((float) npc.getFacingDirection());
-            }
-        }
+        List<InternalNpc> npcs = plugin.getNPCs();
+        for (InternalNpc npc : npcs) npc.injectPlayer(player);
+        SCHEDULER.runTaskLater(plugin, () -> npcs.forEach(npc -> npc.injectPlayer(player)), 10);
     }
 
     /**
@@ -227,40 +300,18 @@ public class Listeners implements Listener {
      * @param e The event callback
      * @since 1.3-pre4
      */
+     
+     /*
     @EventHandler
     public void onEntityMove(EntityMoveEvent e) {
-        Entity et = e.getEntity();
+        final Entity et = e.getEntity();
         List<Player> players = new ArrayList<>();
-        et.getPassengers().forEach(entity1 -> {
-            if(entity1 instanceof Player player) players.add(player);
-        });
-        for (Player player : players) {
-            for (InternalNpc npc : plugin.npcs.values()) {
-                if(player.getWorld() != npc.getWorld()) return;
-                if(npc.getTarget() != null) return;
-                if (player.getLocation().distance(npc.getCurrentLocation()) <= 5) {
-                    npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
-                } else if (e.getFrom().distance(npc.getCurrentLocation()) >= 48 && e.getTo().distance(npc.getCurrentLocation()) <= 48) {
-                    npc.injectPlayer(player);
-                }
-                if (player.getLocation().distance(npc.getCurrentLocation()) > 5) {
-                    Collection<Entity> entities = npc.getWorld().getNearbyEntities(npc.getCurrentLocation(), 2.5, 2.5, 2.5);
-                    entities.removeIf(entity -> entity.getScoreboardTags().contains("NPC"));
-                    for (Entity en : entities) {
-                        if (en.getType() == EntityType.PLAYER) {
-                            Player p = (Player) en;
-                            npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) p).getHandle(), EntityAnchorArgument.Anchor.EYES);
-                            return;
-                        }
-                    }
-                    npc.setYBodyRot((float) npc.getFacingDirection());
-                    npc.setYRot((float) npc.getFacingDirection());
-                    npc.setYHeadRot((float) npc.getFacingDirection());
-                }
-            }
-        }
-
+		et.getPassengers().forEach(entity1 -> {
+			if(entity1 instanceof Player player) players.add(player);
+		});
+        executorService.submit(() -> players.forEach(this::actionPlayerMovement));
     }
+    */
 
     /**
      * <p>The npc injection handler on velocity
@@ -270,34 +321,12 @@ public class Listeners implements Listener {
      */
     @EventHandler
     public void onVelocity(PlayerVelocityEvent e) {
-        Player player = e.getPlayer();
-        for (InternalNpc npc : plugin.npcs.values()) {
-            if(player.getWorld() != npc.getWorld()) return;
-            if(npc.getTarget() != null) return;
-            if (e.getPlayer().getLocation().distance(npc.getCurrentLocation()) <= 5) {
-                npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
-            } else if (player.getLocation().distance(npc.getCurrentLocation()) >= 48) {
-                npc.injectPlayer(player);
-            }
-            if (e.getPlayer().getLocation().distance(npc.getCurrentLocation()) > 5) {
-                Collection<Entity> entities = npc.getWorld().getNearbyEntities(npc.getCurrentLocation(), 2.5, 2.5, 2.5);
-                entities.removeIf(entity -> entity.getScoreboardTags().contains("NPC"));
-                for (Entity en : entities) {
-                    if (en.getType() == EntityType.PLAYER) {
-                        Player p = (Player) en;
-                        npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) p).getHandle(), EntityAnchorArgument.Anchor.EYES);
-                        return;
-                    }
-                }
-                npc.setYBodyRot((float) npc.getFacingDirection());
-                npc.setYRot((float) npc.getFacingDirection());
-                npc.setYHeadRot((float) npc.getFacingDirection());
-            }
-        }
+        actionPlayerMovement(e.getPlayer());
     }
 
     /**
      * <p>The npc follow handler
+     * TODO: Replace with proper Pathfinding.
      * </p>
      * @param e The event callback
      * @since 1.3-pre2
@@ -305,16 +334,17 @@ public class Listeners implements Listener {
     @EventHandler
     public void followHandler(PlayerMoveEvent e) {
         Player player = e.getPlayer();
+        World world = player.getWorld();
+        Location location = player.getLocation();
+        Location to = e.getTo();
         for (InternalNpc npc : plugin.npcs.values()) {
-            if(player.getWorld() != npc.getWorld()) return; //TODO: Make npc travel between dimensions
-            if(npc.getTarget() == player){
-                npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
-                if(npc.getCurrentLocation().distance(e.getTo()) >= .5){
-                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                        if(e.getTo().distance(player.getLocation()) >= 1)
-                            npc.moveTo(new Vec3(e.getTo().x(), e.getTo().y(), e.getTo().z()));
-                    }, 30);
-                }
+            if (world != npc.getWorld()) continue; //TODO: Make npc travel between dimensions
+            if (npc.getTarget() != player) continue;
+            npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
+            if(npc.getCurrentLocation().distanceSquared(to) >= HALF_BLOCK){
+                SCHEDULER.runTaskLater(plugin, () -> {
+                    if (to.distanceSquared(location) >= 1) npc.moveTo(new Vec3(to.x(), to.y(), to.z()));
+                }, 30);
             }
         }
     }
@@ -328,11 +358,16 @@ public class Listeners implements Listener {
     @EventHandler
     public void onTeleport(PlayerTeleportEvent e) {
         Player player = e.getPlayer();
+        Location location = player.getLocation();
+        World world = player.getWorld();
         for (InternalNpc npc : plugin.npcs.values()) {
-            if(player.getWorld() != npc.getWorld()) return;
-            if (player.getLocation().distance(npc.getSpawnLoc()) <= 5) {
+        	Location spawnLocation = npc.getSpawnLoc();
+            if (world != npc.getWorld()) return;
+            
+            double distanceSquared = location.distanceSquared(spawnLocation);
+            if (distanceSquared <= FIVE_BLOCKS) {
                 npc.lookAt(EntityAnchorArgument.Anchor.EYES, ((CraftPlayer) player).getHandle(), EntityAnchorArgument.Anchor.EYES);
-            } else if (player.getLocation().distance(npc.getSpawnLoc()) >= 48 && player.getLocation().distance(npc.getSpawnLoc()) <= 48) {
+            } else if (distanceSquared >= FOURTY_BLOCKS && distanceSquared <= FIFTY_BLOCKS) {
                 npc.injectPlayer(player);
             }
         }
@@ -345,28 +380,35 @@ public class Listeners implements Listener {
      */
     @EventHandler
     public void onDimentionChange(PlayerChangedWorldEvent e) {
+    	Player player = e.getPlayer();
+    	Location location = player.getLocation();
+    	World world = player.getWorld();
         for (InternalNpc npc : plugin.npcs.values()) {
-            if(e.getPlayer().getWorld() == npc.getWorld()) {
-                if(e.getPlayer().getLocation().distance(npc.getCurrentLocation()) <= 48){
-                    npc.injectPlayer(e.getPlayer());
-                }
-            }
+            if (world != npc.getWorld()) continue; 
+            if (location.distanceSquared(npc.getCurrentLocation()) <= FOURTY_BLOCKS) npc.injectPlayer(player);
         }
     }
 
     /**
-     * <p>The npc leave message handler. Cancles the leave message.
+     * <p>The npc leave message handler. Cancels the leave message.
      * </p>
      * @param e The event callback
      * @since 1.0
      */
     @EventHandler
     public void onLeave(PlayerQuitEvent e){
+    	Player player = e.getPlayer();
         for (InternalNpc npc : plugin.npcs.values()) {
-            if(npc.getPlayer().getBukkitEntity().getPlayer() == e.getPlayer()){
-                e.setQuitMessage("");
-            }
+            if (npc.getPlayer().getBukkitEntity().getPlayer() != player) continue;
+            e.setQuitMessage("");
         }
+        plugin.commandWaiting.remove(player);
+     	plugin.nameWaiting.remove(player);
+     	plugin.targetWaiting.remove(player);
+     	plugin.titleWaiting.remove(player);
+     	plugin.messageWaiting.remove(player);
+     	plugin.serverWaiting.remove(player);
+     	plugin.actionbarWaiting.remove(player);
     }
 
     /**
@@ -376,11 +418,36 @@ public class Listeners implements Listener {
      * @since 1.2
      */
     @EventHandler
-    public void onRespawn(PlayerRespawnEvent e){
+    public void onRespawn(PlayerRespawnEvent e) {
+    	Player player = e.getPlayer();
+    	Location respawnLocation = e.getRespawnLocation();
         for (InternalNpc npc : plugin.npcs.values()) {
-            if(e.getRespawnLocation().distance(npc.getCurrentLocation()) <= 48){
-                npc.injectPlayer(e.getPlayer());
-            }
+            if (!respawnLocation.distanceSquared(npc.getCurrentLocation()) <= FOURTY_BLOCKS) continue;
+            npc.injectPlayer(player);
         }
+    }
+    
+    private static class MovementData {
+    	private final UUID uniqueId;
+    	private Location lastLocation;
+    	private double distanceSquared;
+    	
+    	MovementData(UUID uniqueId, Location lastLocation, double distanceSquared) {
+    		this.uniqueId = uniqueId;
+    		this.lastLocation = lastLocation;
+    		this.distanceSquared = distanceSquared;
+    	}
+    	
+    	public UUID getUniqueId() { return uniqueId; }
+    	
+    	public Location getLastLocation() { return lastLocation; }
+    	
+    	public double getDistanceSquared() { return distanceSquared; }
+    	
+    	public void setDistanceSquared(double distanceSquared) { this.distanceSquared = distanceSquared; }
+    	
+    	public void setLastLocation(Location location) { this.lastLocation = location; }
+    	
+    	public MovementData copy() { return new MovementData(uuid, location, distanceSquared); }
     }
 }


### PR DESCRIPTION
I made some amazing changes for the sake of performance of the library :>

> [!CAUTION]
> Might need a little bit of testing.

The most significant performance improvements include but are not limited to:
- The removal of one of the heaviest events in minecraft: The PlayerMoveEvent.
  EntityMoveEvent has not been removed because it would only cause more performance and flexibility issues
  PlayerMoveEvent followHandler will be removed to be replaced by proper pathfinding AI (hence the UnstableAi branch).
  
  PlayerMoveEvent was used to detect movement of a player and distances between the player and an InternalNpc
  For most small servers this does not matter.
  
  but since this PlayerMoveEvent ticks EVERY player, and one tick is only 50 milliseconds, it can burn those millis fast and produce overhead.
  This is a problem because of the poor ticking design of minecraft that ruin the performance.
  
  Instead, I replaced it with a ScheduledExecutorService that will asynchronously run the process of tracking old movements and then replacing them with new movement locations.
  this functions very similarily to the old one, just a lot faster, better handled, asynchronous, less frequently called (but unnoticable)
  And much more caches (in memory).
  
> [!WARNING]  
> Listeners#stop method should definitely be called at JavaPlugin#onDisable so that the cached threads in the ScheduledExecutorService would shut down and unallocate allocated memory

- The discontinue of using Location#distance which uses a very costly root function called "square root", and use Location#distanceSquared
  This is not usually a problem and it's definitely okay to use Math#sqrt once in a while.
  
  But when it runs in hot code, like EntityMoveEvent, (this varies, but PlayerVelocityEvent), and some other events in Listener.
  It can lead to some overhead and cause the TPS to drop.
  
  Instead we use Location#distanceSquared, one problem with using Location#distanceSquared is sometimes the numbers look
  more confusing than when using Location#distance (48 * 48 equals around 2304), so I have introduced helper constants that help with identifying how many blocks is a number.
  
  5 blocks is FIVE_BLOCKS, 0.25 is HALF_BLOCK (sqrt(0.5) = 0.25), 48 is FOURTY_BLOCKS
  

Now, There was just two issues when I looked at this code:
1. There was some really unnecessary nesting in that code, by being a natural never-nester, I made this code good myself (because I coded optimizations for this class so I'm gonna be just a little bit narcissist)
   so unless it was necessary, I removed any nesting and replaced it with a "return" or "continue" that
   would later be removed by the compiler anyways and nest the code for us.
   
2. There is a possibility that a player CAN leave the server while the plugin waits for them to do something;
   like name an NPC, or wait for a message, or add args, etc.
   There would be dead Player objects that just don't do anything and take up memory, and Player objects take LOTS of memory.
   
   to fix this issue; there were 3 ways to fix this issue:
   - Convert Player into UUIDs since UUID take only 16 bits of ram (excluding the class initialization memory consumption itself) since it only contains 2 longs per instance.
   - Properly remove Players from Sets and Lists
   - Sleep eight hours in college without faili- I mean give the player loads of problems to deal with when rejoining.
   Now the last option can be a config (just fail college) by just not removing the stuff on leave.
   
Fixing these issue can improve code quality and code maintainability + readability between others.

These were not made by an IDE (D:) but these were compile-time tested.